### PR TITLE
added fluid tags that are used by northstar redux to indentify fuels

### DIFF
--- a/src/main/resources/data/c/tags/fluid/methane.json
+++ b/src/main/resources/data/c/tags/fluid/methane.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "chemica:methane"
+  ]
+}

--- a/src/main/resources/data/chemica/northstar/fuel_type/hydrogen_fuel.json
+++ b/src/main/resources/data/chemica/northstar/fuel_type/hydrogen_fuel.json
@@ -1,0 +1,6 @@
+{
+  "fluids": ["chemica:hydrogen_fuel"],
+  "gj_per_mb": 1,
+  "combustion_engine_use": 0.16,
+  "combustion_engine_rpm": 64.0
+}


### PR DESCRIPTION
Added fluid Tags and Fluid registry for chemica fluids.
(in theory the registry for liquid hydrogen is missing but that is a tfmg fluid and ill make a pr there)