### PR TITLE
added vat recipes for processing garnished:*_zultanites

### DIFF
--- a/src/main/resources/data/chemica/recipe/vat_machine_recipe/centrifuge/iron_nugget_from_zultanite.json
+++ b/src/main/resources/data/chemica/recipe/vat_machine_recipe/centrifuge/iron_nugget_from_zultanite.json
@@ -1,0 +1,34 @@
+{
+    "neoforge:conditions": [
+        {
+            "type": "neoforge:mod_loaded",
+            "modid": "creategarnished"
+        }
+    ],
+    "type": "tfmg:vat_machine_recipe",
+    "allowedVatTypes": ["tfmg:steel_vat", "tfmg:firebrick_lined_vat"],
+    "ingredients": [
+      {
+        "type": "neoforge:single",
+        "amount": 10,
+        "fluid": "chemica:chlorine"
+      },
+      {
+        "item": "garnished:red_zultanite"
+      }
+    ],
+    "machines": ["tfmg:centrifuge"],
+    "minSize": 3,
+    "processingTime": 100,
+    "results": [
+      {
+        "amount": 5,
+        "id": "minecraft:iron_nugget"
+      },
+      {
+        "chance": 0.5,
+        "amount": 1,
+        "id": "minecraft:redstone"
+      }
+    ]
+  }

--- a/src/main/resources/data/chemica/recipe/vat_machine_recipe/electrolysis/copper_nugget_from_zultanite.json
+++ b/src/main/resources/data/chemica/recipe/vat_machine_recipe/electrolysis/copper_nugget_from_zultanite.json
@@ -1,0 +1,45 @@
+{
+    "neoforge:conditions": [
+        {
+            "type": "neoforge:mod_loaded",
+            "modid": "creategarnished"
+        }
+    ],
+    "type": "tfmg:vat_machine_recipe",
+    "heat_requirement": "heated",
+    "allowedVatTypes": ["tfmg:steel_vat", "tfmg:firebrick_lined_vat"],
+    "ingredients": [
+      {
+        "type": "neoforge:single",
+        "amount": 10,
+        "fluid": "tfmg:sulfuric_acid"
+      },
+      {
+        "item": "garnished:green_zultanite",
+        "amount": 5
+      }
+    ],
+    "machines": ["tfmg:electrode", "tfmg:electrode"],
+    "minSize": 1,
+    "processingTime": 200,
+    "results": [
+      {
+        "amount": 3,
+        "id": "create:copper_nugget"
+      },
+      {
+        "chance": 0.2,
+        "amount": 1,
+        "id": "chemica:silver_nugget"
+      },
+      {
+        "chance": 0.1,
+        "amount": 1,
+        "id": "minecraft:gold_nugget"
+      },
+      {
+        "amount": 5,
+        "id": "tfmg:sulfuric_acid"
+      }
+    ]
+  }

--- a/src/main/resources/data/chemica/recipe/vat_machine_recipe/electrolysis/zinc_nugget_from_zultanite.json
+++ b/src/main/resources/data/chemica/recipe/vat_machine_recipe/electrolysis/zinc_nugget_from_zultanite.json
@@ -1,0 +1,35 @@
+{
+    "neoforge:conditions": [
+        {
+            "type": "neoforge:mod_loaded",
+            "modid": "creategarnished"
+        }
+    ],
+    "type": "tfmg:vat_machine_recipe",
+    "heat_requirement": "heated",
+    "allowedVatTypes": ["tfmg:steel_vat", "tfmg:firebrick_lined_vat"],
+    "ingredients": [
+      {
+        "type": "neoforge:single",
+        "amount": 10,
+        "fluid": "tfmg:sulfuric_acid"
+      },
+      {
+        "item": "garnished:blue_zultanite",
+        "amount": 5
+      }
+    ],
+    "machines": ["tfmg:electrode", "tfmg:electrode"],
+    "minSize": 1,
+    "processingTime": 200,
+    "results": [
+      {
+        "amount": 3,
+        "id": "create:zinc_nugget"
+      },
+      {
+        "amount": 5,
+        "id": "tfmg:sulfuric_acid"
+      }
+    ]
+  }

--- a/src/main/resources/data/chemica/recipe/vat_machine_recipe/vat_reaction/gold_nugget_from_zultanite.json
+++ b/src/main/resources/data/chemica/recipe/vat_machine_recipe/vat_reaction/gold_nugget_from_zultanite.json
@@ -1,0 +1,46 @@
+{
+    "neoforge:conditions": [
+        {
+            "type": "neoforge:mod_loaded",
+            "modid": "creategarnished"
+        }
+    ],
+    "type": "tfmg:vat_machine_recipe",
+    "heat_requirement": "heated",
+    "allowedVatTypes": ["tfmg:steel_vat", "tfmg:firebrick_lined_vat"],
+    "ingredients": [
+      {
+        "type": "neoforge:single",
+        "amount": 5,
+        "fluid": "chemica:nitric_acid"
+      },
+      {
+        "type": "neoforge:single",
+        "amount": 10,
+        "fluid": "chemica:hydrochloric_acid"
+      },
+      {
+        "item": "garnished:yellow_zultanite",
+        "amount": 5
+      }
+    ],
+    "machines": [],
+    "minSize": 1,
+    "processingTime": 300,
+    "results": [
+      {
+        "amount": 3,
+        "id": "create:gold_nugget"
+      },
+      {
+        "chance": 0.5,
+        "amount": 2,
+        "id": "create:zinc_nugget"
+      },
+      {
+        "chance": 0.2,
+        "amount": 1,
+        "id": "tfmg:lead_nugget"
+      }
+    ]
+  }


### PR DESCRIPTION
On our server we also have create garnished installed and some player requested recipes to be able to process the zultanite variants not only via crushing but also via VATs for better results.

With the help of AI these semi realistic recipes were created and i thought i share them